### PR TITLE
change bucket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ deploy:
   secret_access_key: $SECRET_ACCESS_KEY
   skip_cleanup: true
   region: us-east-1
-  bucket: genomic-data-vis.org
+  bucket: genocat.tools
   local_dir: _site
   acl: public_read


### PR DESCRIPTION
In [aws](https://console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::922145058410:policy/genomic-data-vis$jsonEditor) I've updated the policy:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": [
                "s3:AbortMultipartUpload",
                "s3:DeleteObject",
                "s3:GetObject",
                "s3:GetObjectAcl",
                "s3:PutObject",
                "s3:PutObjectAcl"
            ],
            "Resource": [
                "arn:aws:s3:::genocat.tools",
                "arn:aws:s3:::genocat.tools/*"
            ]
        }
    ]
}
```

If I've done everything right, after the travis build, http://genocat.tools/ will be updated.